### PR TITLE
Convert to TypeScript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,27 @@
 .PHONY: sync
 sync:
-	uv sync --all-extras --all-packages --group dev
+	npm install
 
 .PHONY: format
-format: 
-	uv run ruff format
+format:
+	npx prettier --write .
 
 .PHONY: lint
-lint: 
-	uv run ruff check
+lint:
+	npx eslint .
 
-.PHONY: mypy
-mypy: 
-	uv run mypy .
+.PHONY: build
+build:
+	npx tsc
 
 .PHONY: tests
-tests: 
-	uv run pytest 
-
-.PHONY: old_version_tests
-old_version_tests: 
-	UV_PROJECT_ENVIRONMENT=.venv_39 uv run --python 3.9 -m pytest
-	UV_PROJECT_ENVIRONMENT=.venv_39 uv run --python 3.9 -m mypy .
-
-.PHONY: build-docs
-build-docs:
-	uv run mkdocs build
+tests:
+	npx jest
 
 .PHONY: serve-docs
 serve-docs:
-	uv run mkdocs serve
+	npx serve docs
 
 .PHONY: deploy-docs
 deploy-docs:
-	uv run mkdocs gh-deploy --force --verbose
-	
+	npx gh-pages -d docs

--- a/README.md
+++ b/README.md
@@ -15,97 +15,89 @@ Explore the [examples](examples) directory to see the SDK in action, and read ou
 
 ## Get started
 
-1. Set up your Python environment
+1. Set up your Node.js environment
 
 ```
-python -m venv env
-source env/bin/activate
+npm install
 ```
 
 2. Install Agents SDK
 
 ```
-pip install openai-agents
+npm install openai-agents
 ```
 
 ## Hello world example
 
-```python
-from agents import Agent, Runner
+```typescript
+import { Agent, Runner } from 'agents';
 
-agent = Agent(name="Assistant", instructions="You are a helpful assistant")
+const agent = new Agent({ name: "Assistant", instructions: "You are a helpful assistant" });
 
-result = Runner.run_sync(agent, "Write a haiku about recursion in programming.")
-print(result.final_output)
+Runner.run(agent, "Write a haiku about recursion in programming.").then(result => {
+    console.log(result.finalOutput);
+});
 
-# Code within the code,
-# Functions calling themselves,
-# Infinite loop's dance.
+// Code within the code,
+// Functions calling themselves,
+// Infinite loop's dance.
 ```
 
 (_If running this, ensure you set the `OPENAI_API_KEY` environment variable_)
 
 ## Handoffs example
 
-```py
-from agents import Agent, Runner
-import asyncio
+```typescript
+import { Agent, Runner } from 'agents';
 
-spanish_agent = Agent(
-    name="Spanish agent",
-    instructions="You only speak Spanish.",
-)
+const spanishAgent = new Agent({
+    name: "Spanish agent",
+    instructions: "You only speak Spanish.",
+});
 
-english_agent = Agent(
-    name="English agent",
-    instructions="You only speak English",
-)
+const englishAgent = new Agent({
+    name: "English agent",
+    instructions: "You only speak English",
+});
 
-triage_agent = Agent(
-    name="Triage agent",
-    instructions="Handoff to the appropriate agent based on the language of the request.",
-    handoffs=[spanish_agent, english_agent],
-)
+const triageAgent = new Agent({
+    name: "Triage agent",
+    instructions: "Handoff to the appropriate agent based on the language of the request.",
+    handoffs: [spanishAgent, englishAgent],
+});
 
-
-async def main():
-    result = await Runner.run(triage_agent, input="Hola, ¿cómo estás?")
-    print(result.final_output)
-    # ¡Hola! Estoy bien, gracias por preguntar. ¿Y tú, cómo estás?
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
+Runner.run(triageAgent, "Hola, ¿cómo estás?").then(result => {
+    console.log(result.finalOutput);
+    // ¡Hola! Estoy bien, gracias por preguntar. ¿Y tú, cómo estás?
+});
 ```
 
 ## Functions example
 
-```python
-import asyncio
+```typescript
+import { Agent, Runner, functionTool } from 'agents';
 
-from agents import Agent, Runner, function_tool
+const getWeather = functionTool({
+    name: "getWeather",
+    description: "Get the weather for a city",
+    parameters: {
+        city: { type: "string" }
+    },
+    handler: (params) => {
+        return `The weather in ${params.city} is sunny.`;
+    }
+});
 
+const agent = new Agent({
+    name: "Hello world",
+    instructions: "You are a helpful agent.",
+    tools: [getWeather],
+});
 
-@function_tool
-def get_weather(city: str) -> str:
-    return f"The weather in {city} is sunny."
-
-
-agent = Agent(
-    name="Hello world",
-    instructions="You are a helpful agent.",
-    tools=[get_weather],
-)
-
-
-async def main():
-    result = await Runner.run(agent, input="What's the weather in Tokyo?")
-    print(result.final_output)
-    # The weather in Tokyo is sunny.
-
-
-if __name__ == "__main__":
-    asyncio.run(main())
+Runner.run(agent, "What's the weather in Tokyo?").then(result => {
+    console.log(result.finalOutput);
+    // The weather in Tokyo is sunny.
+});
 ```
 
 ## The agent loop
@@ -118,19 +110,19 @@ When you call `Runner.run()`, we run a loop until we get a final output.
 4. If the response has a handoff, we set the agent to the new agent and go back to step 1.
 5. We process the tool calls (if any) and append the tool responses messsages. Then we go to step 1.
 
-There is a `max_turns` parameter that you can use to limit the number of times the loop executes.
+There is a `maxTurns` parameter that you can use to limit the number of times the loop executes.
 
 ### Final output
 
 Final output is the last thing the agent produces in the loop.
 
-1.  If you set an `output_type` on the agent, the final output is when the LLM returns something of that type. We use [structured outputs](https://platform.openai.com/docs/guides/structured-outputs) for this.
-2.  If there's no `output_type` (i.e. plain text responses), then the first LLM response without any tool calls or handoffs is considered as the final output.
+1.  If you set an `outputType` on the agent, the final output is when the LLM returns something of that type. We use [structured outputs](https://platform.openai.com/docs/guides/structured-outputs) for this.
+2.  If there's no `outputType` (i.e. plain text responses), then the first LLM response without any tool calls or handoffs is considered as the final output.
 
 As a result, the mental model for the agent loop is:
 
-1. If the current agent has an `output_type`, the loop runs until the agent produces structured output matching that type.
-2. If the current agent does not have an `output_type`, the loop runs until the current agent produces a message without any tool calls/handoffs.
+1. If the current agent has an `outputType`, the loop runs until the agent produces structured output matching that type.
+2. If the current agent does not have an `outputType`, the loop runs until the current agent produces a message without any tool calls/handoffs.
 
 ## Common agent patterns
 
@@ -158,8 +150,8 @@ make sync
 
 ```
 make tests  # run tests
-make mypy   # run typechecker
 make lint   # run linter
+make build  # build TypeScript code
 ```
 
 ## Acknowledgements

--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -1,0 +1,95 @@
+import { MaybeAwaitable } from './_utils';
+import { InputGuardrail, OutputGuardrail } from './guardrail';
+import { Handoff } from './handoffs';
+import { ItemHelpers } from './items';
+import { logger } from './logger';
+import { ModelSettings } from './model_settings';
+import { Model } from './models/interface';
+import { RunContextWrapper, TContext } from './run_context';
+import { Tool, function_tool } from './tool';
+import { AgentHooks } from './lifecycle';
+import { RunResult } from './result';
+
+export interface AgentOptions<TContext> {
+  name: string;
+  instructions?: string | ((context: RunContextWrapper<TContext>, agent: Agent<TContext>) => MaybeAwaitable<string>);
+  handoffDescription?: string;
+  handoffs?: Array<Agent<any> | Handoff<TContext>>;
+  model?: string | Model;
+  modelSettings?: ModelSettings;
+  tools?: Tool[];
+  inputGuardrails?: InputGuardrail<TContext>[];
+  outputGuardrails?: OutputGuardrail<TContext>[];
+  outputType?: any;
+  hooks?: AgentHooks<TContext>;
+}
+
+export class Agent<TContext> {
+  name: string;
+  instructions?: string | ((context: RunContextWrapper<TContext>, agent: Agent<TContext>) => MaybeAwaitable<string>);
+  handoffDescription?: string;
+  handoffs: Array<Agent<any> | Handoff<TContext>>;
+  model?: string | Model;
+  modelSettings: ModelSettings;
+  tools: Tool[];
+  inputGuardrails: InputGuardrail<TContext>[];
+  outputGuardrails: OutputGuardrail<TContext>[];
+  outputType?: any;
+  hooks?: AgentHooks<TContext>;
+
+  constructor(options: AgentOptions<TContext>) {
+    this.name = options.name;
+    this.instructions = options.instructions;
+    this.handoffDescription = options.handoffDescription;
+    this.handoffs = options.handoffs || [];
+    this.model = options.model;
+    this.modelSettings = options.modelSettings || new ModelSettings();
+    this.tools = options.tools || [];
+    this.inputGuardrails = options.inputGuardrails || [];
+    this.outputGuardrails = options.outputGuardrails || [];
+    this.outputType = options.outputType;
+    this.hooks = options.hooks;
+  }
+
+  clone(options: Partial<AgentOptions<TContext>>): Agent<TContext> {
+    return new Agent<TContext>({
+      ...this,
+      ...options,
+    });
+  }
+
+  asTool(
+    toolName?: string,
+    toolDescription?: string,
+    customOutputExtractor?: (output: RunResult) => Promise<string>
+  ): Tool {
+    const runAgent = async (context: RunContextWrapper<any>, input: string): Promise<string> => {
+      const { Runner } = await import('./run');
+      const output = await Runner.run({
+        startingAgent: this,
+        input,
+        context: context.context,
+      });
+      if (customOutputExtractor) {
+        return await customOutputExtractor(output);
+      }
+      return ItemHelpers.textMessageOutputs(output.newItems);
+    };
+
+    return function_tool({
+      nameOverride: toolName || this.name.replace(/\s+/g, '_').toLowerCase(),
+      descriptionOverride: toolDescription || '',
+    })(runAgent);
+  }
+
+  async getSystemPrompt(runContext: RunContextWrapper<TContext>): Promise<string | undefined> {
+    if (typeof this.instructions === 'string') {
+      return this.instructions;
+    } else if (typeof this.instructions === 'function') {
+      return await this.instructions(runContext, this);
+    } else if (this.instructions !== undefined) {
+      logger.error(`Instructions must be a string or a function, got ${this.instructions}`);
+    }
+    return undefined;
+  }
+}

--- a/src/agents/computer.ts
+++ b/src/agents/computer.ts
@@ -1,0 +1,30 @@
+export type Environment = "mac" | "windows" | "ubuntu" | "browser";
+export type Button = "left" | "right" | "wheel" | "back" | "forward";
+
+export interface Computer {
+  environment: Environment;
+  dimensions: [number, number];
+  screenshot(): string;
+  click(x: number, y: number, button: Button): void;
+  doubleClick(x: number, y: number): void;
+  scroll(x: number, y: number, scrollX: number, scrollY: number): void;
+  type(text: string): void;
+  wait(): void;
+  move(x: number, y: number): void;
+  keypress(keys: string[]): void;
+  drag(path: [number, number][]): void;
+}
+
+export interface AsyncComputer {
+  environment: Environment;
+  dimensions: [number, number];
+  screenshot(): Promise<string>;
+  click(x: number, y: number, button: Button): Promise<void>;
+  doubleClick(x: number, y: number): Promise<void>;
+  scroll(x: number, y: number, scrollX: number, scrollY: number): Promise<void>;
+  type(text: string): Promise<void>;
+  wait(): Promise<void>;
+  move(x: number, y: number): Promise<void>;
+  keypress(keys: string[]): Promise<void>;
+  drag(path: [number, number][]): Promise<void>;
+}

--- a/src/agents/exceptions.ts
+++ b/src/agents/exceptions.ts
@@ -1,0 +1,49 @@
+import { InputGuardrailResult, OutputGuardrailResult } from './guardrail';
+
+export class AgentsException extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'AgentsException';
+  }
+}
+
+export class MaxTurnsExceeded extends AgentsException {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MaxTurnsExceeded';
+  }
+}
+
+export class ModelBehaviorError extends AgentsException {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ModelBehaviorError';
+  }
+}
+
+export class UserError extends AgentsException {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UserError';
+  }
+}
+
+export class InputGuardrailTripwireTriggered extends AgentsException {
+  guardrailResult: InputGuardrailResult;
+
+  constructor(guardrailResult: InputGuardrailResult) {
+    super(`Guardrail ${guardrailResult.guardrail.constructor.name} triggered tripwire`);
+    this.guardrailResult = guardrailResult;
+    this.name = 'InputGuardrailTripwireTriggered';
+  }
+}
+
+export class OutputGuardrailTripwireTriggered extends AgentsException {
+  guardrailResult: OutputGuardrailResult;
+
+  constructor(guardrailResult: OutputGuardrailResult) {
+    super(`Guardrail ${guardrailResult.guardrail.constructor.name} triggered tripwire`);
+    this.guardrailResult = guardrailResult;
+    this.name = 'OutputGuardrailTripwireTriggered';
+  }
+}

--- a/src/agents/guardrail.ts
+++ b/src/agents/guardrail.ts
@@ -1,0 +1,214 @@
+import { MaybeAwaitable } from './_utils';
+import { UserError } from './exceptions';
+import { TResponseInputItem } from './items';
+import { RunContextWrapper, TContext } from './run_context';
+import { Agent } from './agent';
+
+export interface GuardrailFunctionOutput {
+  outputInfo: any;
+  tripwireTriggered: boolean;
+}
+
+export interface InputGuardrailResult<TContext> {
+  guardrail: InputGuardrail<TContext>;
+  output: GuardrailFunctionOutput;
+}
+
+export interface OutputGuardrailResult<TContext> {
+  guardrail: OutputGuardrail<TContext>;
+  agentOutput: any;
+  agent: Agent<any>;
+  output: GuardrailFunctionOutput;
+}
+
+export class InputGuardrail<TContext> {
+  guardrailFunction: (
+    context: RunContextWrapper<TContext>,
+    agent: Agent<any>,
+    input: string | TResponseInputItem[]
+  ) => MaybeAwaitable<GuardrailFunctionOutput>;
+  name?: string;
+
+  constructor(
+    guardrailFunction: (
+      context: RunContextWrapper<TContext>,
+      agent: Agent<any>,
+      input: string | TResponseInputItem[]
+    ) => MaybeAwaitable<GuardrailFunctionOutput>,
+    name?: string
+  ) {
+    this.guardrailFunction = guardrailFunction;
+    this.name = name;
+  }
+
+  getName(): string {
+    return this.name || this.guardrailFunction.name;
+  }
+
+  async run(
+    agent: Agent<any>,
+    input: string | TResponseInputItem[],
+    context: RunContextWrapper<TContext>
+  ): Promise<InputGuardrailResult<TContext>> {
+    if (typeof this.guardrailFunction !== 'function') {
+      throw new UserError(`Guardrail function must be callable, got ${this.guardrailFunction}`);
+    }
+
+    const output = this.guardrailFunction(context, agent, input);
+    if (output instanceof Promise) {
+      return {
+        guardrail: this,
+        output: await output,
+      };
+    }
+
+    return {
+      guardrail: this,
+      output,
+    };
+  }
+}
+
+export class OutputGuardrail<TContext> {
+  guardrailFunction: (
+    context: RunContextWrapper<TContext>,
+    agent: Agent<any>,
+    agentOutput: any
+  ) => MaybeAwaitable<GuardrailFunctionOutput>;
+  name?: string;
+
+  constructor(
+    guardrailFunction: (
+      context: RunContextWrapper<TContext>,
+      agent: Agent<any>,
+      agentOutput: any
+    ) => MaybeAwaitable<GuardrailFunctionOutput>,
+    name?: string
+  ) {
+    this.guardrailFunction = guardrailFunction;
+    this.name = name;
+  }
+
+  getName(): string {
+    return this.name || this.guardrailFunction.name;
+  }
+
+  async run(
+    context: RunContextWrapper<TContext>,
+    agent: Agent<any>,
+    agentOutput: any
+  ): Promise<OutputGuardrailResult<TContext>> {
+    if (typeof this.guardrailFunction !== 'function') {
+      throw new UserError(`Guardrail function must be callable, got ${this.guardrailFunction}`);
+    }
+
+    const output = this.guardrailFunction(context, agent, agentOutput);
+    if (output instanceof Promise) {
+      return {
+        guardrail: this,
+        agent,
+        agentOutput,
+        output: await output,
+      };
+    }
+
+    return {
+      guardrail: this,
+      agent,
+      agentOutput,
+      output,
+    };
+  }
+}
+
+export function inputGuardrail<TContext>(
+  func: (
+    context: RunContextWrapper<TContext>,
+    agent: Agent<any>,
+    input: string | TResponseInputItem[]
+  ) => MaybeAwaitable<GuardrailFunctionOutput>
+): InputGuardrail<TContext>;
+export function inputGuardrail<TContext>(
+  options: { name?: string }
+): (
+  func: (
+    context: RunContextWrapper<TContext>,
+    agent: Agent<any>,
+    input: string | TResponseInputItem[]
+  ) => MaybeAwaitable<GuardrailFunctionOutput>
+) => InputGuardrail<TContext>;
+export function inputGuardrail<TContext>(
+  funcOrOptions:
+    | ((
+        context: RunContextWrapper<TContext>,
+        agent: Agent<any>,
+        input: string | TResponseInputItem[]
+      ) => MaybeAwaitable<GuardrailFunctionOutput>)
+    | { name?: string }
+):
+  | InputGuardrail<TContext>
+  | ((
+      func: (
+        context: RunContextWrapper<TContext>,
+        agent: Agent<any>,
+        input: string | TResponseInputItem[]
+      ) => MaybeAwaitable<GuardrailFunctionOutput>
+    ) => InputGuardrail<TContext>) {
+  if (typeof funcOrOptions === 'function') {
+    return new InputGuardrail(funcOrOptions);
+  }
+
+  return (
+    func: (
+      context: RunContextWrapper<TContext>,
+      agent: Agent<any>,
+      input: string | TResponseInputItem[]
+    ) => MaybeAwaitable<GuardrailFunctionOutput>
+  ) => new InputGuardrail(func, funcOrOptions.name);
+}
+
+export function outputGuardrail<TContext>(
+  func: (
+    context: RunContextWrapper<TContext>,
+    agent: Agent<any>,
+    agentOutput: any
+  ) => MaybeAwaitable<GuardrailFunctionOutput>
+): OutputGuardrail<TContext>;
+export function outputGuardrail<TContext>(
+  options: { name?: string }
+): (
+  func: (
+    context: RunContextWrapper<TContext>,
+    agent: Agent<any>,
+    agentOutput: any
+  ) => MaybeAwaitable<GuardrailFunctionOutput>
+) => OutputGuardrail<TContext>;
+export function outputGuardrail<TContext>(
+  funcOrOptions:
+    | ((
+        context: RunContextWrapper<TContext>,
+        agent: Agent<any>,
+        agentOutput: any
+      ) => MaybeAwaitable<GuardrailFunctionOutput>)
+    | { name?: string }
+):
+  | OutputGuardrail<TContext>
+  | ((
+      func: (
+        context: RunContextWrapper<TContext>,
+        agent: Agent<any>,
+        agentOutput: any
+      ) => MaybeAwaitable<GuardrailFunctionOutput>
+    ) => OutputGuardrail<TContext>) {
+  if (typeof funcOrOptions === 'function') {
+    return new OutputGuardrail(funcOrOptions);
+  }
+
+  return (
+    func: (
+      context: RunContextWrapper<TContext>,
+      agent: Agent<any>,
+      agentOutput: any
+    ) => MaybeAwaitable<GuardrailFunctionOutput>
+  ) => new OutputGuardrail(func, funcOrOptions.name);
+}

--- a/src/agents/handoffs.ts
+++ b/src/agents/handoffs.ts
@@ -1,0 +1,121 @@
+import { MaybeAwaitable } from './_utils';
+import { ModelBehaviorError, UserError } from './exceptions';
+import { RunItem, TResponseInputItem } from './items';
+import { RunContextWrapper, TContext } from './run_context';
+import { ensureStrictJsonSchema } from './strict_schema';
+import { SpanError, attachErrorToCurrentSpan } from './tracing/spans';
+import { Agent } from './agent';
+
+export type THandoffInput = any;
+
+export interface HandoffInputData {
+  inputHistory: string | TResponseInputItem[];
+  preHandoffItems: RunItem[];
+  newItems: RunItem[];
+}
+
+export type HandoffInputFilter = (handoffInputData: HandoffInputData) => HandoffInputData;
+
+export interface HandoffOptions<TContext> {
+  toolName: string;
+  toolDescription: string;
+  inputJsonSchema: Record<string, any>;
+  onInvokeHandoff: (context: RunContextWrapper<any>, inputJson: string) => Promise<Agent<TContext>>;
+  agentName: string;
+  inputFilter?: HandoffInputFilter;
+  strictJsonSchema?: boolean;
+}
+
+export class Handoff<TContext> {
+  toolName: string;
+  toolDescription: string;
+  inputJsonSchema: Record<string, any>;
+  onInvokeHandoff: (context: RunContextWrapper<any>, inputJson: string) => Promise<Agent<TContext>>;
+  agentName: string;
+  inputFilter?: HandoffInputFilter;
+  strictJsonSchema: boolean;
+
+  constructor(options: HandoffOptions<TContext>) {
+    this.toolName = options.toolName;
+    this.toolDescription = options.toolDescription;
+    this.inputJsonSchema = options.inputJsonSchema;
+    this.onInvokeHandoff = options.onInvokeHandoff;
+    this.agentName = options.agentName;
+    this.inputFilter = options.inputFilter;
+    this.strictJsonSchema = options.strictJsonSchema ?? true;
+  }
+
+  getTransferMessage(agent: Agent<any>): string {
+    return `{'assistant': '${agent.name}'}`;
+  }
+
+  static defaultToolName(agent: Agent<any>): string {
+    return `transfer_to_${agent.name.replace(/\s+/g, '_').toLowerCase()}`;
+  }
+
+  static defaultToolDescription(agent: Agent<any>): string {
+    return `Handoff to the ${agent.name} agent to handle the request. ${agent.handoffDescription || ''}`;
+  }
+}
+
+export function handoff<TContext>(
+  agent: Agent<TContext>,
+  options: {
+    toolNameOverride?: string;
+    toolDescriptionOverride?: string;
+    onHandoff?: (context: RunContextWrapper<any>, input: THandoffInput) => MaybeAwaitable<void>;
+    inputType?: new () => THandoffInput;
+    inputFilter?: HandoffInputFilter;
+  } = {}
+): Handoff<TContext> {
+  const {
+    toolNameOverride,
+    toolDescriptionOverride,
+    onHandoff,
+    inputType,
+    inputFilter,
+  } = options;
+
+  const inputJsonSchema = inputType ? new inputType().constructor : {};
+  const typeAdapter = inputType ? new inputType() : null;
+
+  async function _invokeHandoff(
+    context: RunContextWrapper<any>,
+    inputJson: string | null = null
+  ): Promise<Agent<any>> {
+    if (inputType && typeAdapter) {
+      if (inputJson === null) {
+        attachErrorToCurrentSpan(
+          new SpanError({
+            message: 'Handoff function expected non-null input, but got None',
+            data: { details: 'inputJson is None' },
+          })
+        );
+        throw new ModelBehaviorError('Handoff function expected non-null input, but got None');
+      }
+
+      const validatedInput = JSON.parse(inputJson);
+      if (onHandoff) {
+        await onHandoff(context, validatedInput);
+      }
+    } else if (onHandoff) {
+      await onHandoff(context, undefined);
+    }
+
+    return agent;
+  }
+
+  const toolName = toolNameOverride || Handoff.defaultToolName(agent);
+  const toolDescription = toolDescriptionOverride || Handoff.defaultToolDescription(agent);
+
+  const strictJsonSchema = ensureStrictJsonSchema(inputJsonSchema);
+
+  return new Handoff({
+    toolName,
+    toolDescription,
+    inputJsonSchema: strictJsonSchema,
+    onInvokeHandoff: _invokeHandoff,
+    agentName: agent.name,
+    inputFilter,
+  });
+}

--- a/src/agents/items.ts
+++ b/src/agents/items.ts
@@ -1,0 +1,144 @@
+import { BaseModel } from 'pydantic';
+import { Agent } from './agent';
+import { Usage } from './usage';
+import { AgentsException, ModelBehaviorError } from './exceptions';
+import { Response, ResponseInputItemParam, ResponseOutputItem, ResponseStreamEvent, ResponseOutputMessage, ResponseOutputText, ResponseOutputRefusal, ResponseFunctionToolCall, ResponseComputerToolCall, ResponseFileSearchToolCall, ResponseFunctionWebSearch, FunctionCallOutput, ComputerCallOutput, Reasoning } from 'openai/types/responses';
+
+export type TResponse = Response;
+export type TResponseInputItem = ResponseInputItemParam;
+export type TResponseOutputItem = ResponseOutputItem;
+export type TResponseStreamEvent = ResponseStreamEvent;
+
+export abstract class RunItemBase<T extends TResponseOutputItem | TResponseInputItem> {
+  agent: Agent<any>;
+  rawItem: T;
+
+  constructor(agent: Agent<any>, rawItem: T) {
+    this.agent = agent;
+    this.rawItem = rawItem;
+  }
+
+  toInputItem(): TResponseInputItem {
+    if (typeof this.rawItem === 'object') {
+      return this.rawItem as TResponseInputItem;
+    } else if (this.rawItem instanceof BaseModel) {
+      return this.rawItem.model_dump({ exclude_unset: true }) as TResponseInputItem;
+    } else {
+      throw new AgentsException(`Unexpected raw item type: ${typeof this.rawItem}`);
+    }
+  }
+}
+
+export class MessageOutputItem extends RunItemBase<ResponseOutputMessage> {
+  type: 'message_output_item' = 'message_output_item';
+}
+
+export class HandoffCallItem extends RunItemBase<ResponseFunctionToolCall> {
+  type: 'handoff_call_item' = 'handoff_call_item';
+}
+
+export class HandoffOutputItem extends RunItemBase<TResponseInputItem> {
+  sourceAgent: Agent<any>;
+  targetAgent: Agent<any>;
+  type: 'handoff_output_item' = 'handoff_output_item';
+
+  constructor(agent: Agent<any>, rawItem: TResponseInputItem, sourceAgent: Agent<any>, targetAgent: Agent<any>) {
+    super(agent, rawItem);
+    this.sourceAgent = sourceAgent;
+    this.targetAgent = targetAgent;
+  }
+}
+
+export type ToolCallItemTypes = ResponseFunctionToolCall | ResponseComputerToolCall | ResponseFileSearchToolCall | ResponseFunctionWebSearch;
+
+export class ToolCallItem extends RunItemBase<ToolCallItemTypes> {
+  type: 'tool_call_item' = 'tool_call_item';
+}
+
+export class ToolCallOutputItem extends RunItemBase<FunctionCallOutput | ComputerCallOutput> {
+  output: string;
+  type: 'tool_call_output_item' = 'tool_call_output_item';
+
+  constructor(agent: Agent<any>, rawItem: FunctionCallOutput | ComputerCallOutput, output: string) {
+    super(agent, rawItem);
+    this.output = output;
+  }
+}
+
+export class ReasoningItem extends RunItemBase<Reasoning> {
+  type: 'reasoning_item' = 'reasoning_item';
+}
+
+export type RunItem = MessageOutputItem | HandoffCallItem | HandoffOutputItem | ToolCallItem | ToolCallOutputItem | ReasoningItem;
+
+export class ModelResponse {
+  output: TResponseOutputItem[];
+  usage: Usage;
+  referenceableId: string | null;
+
+  constructor(output: TResponseOutputItem[], usage: Usage, referenceableId: string | null) {
+    this.output = output;
+    this.usage = usage;
+    this.referenceableId = referenceableId;
+  }
+
+  toInputItems(): TResponseInputItem[] {
+    return this.output.map(item => item.model_dump({ exclude_unset: true }) as TResponseInputItem);
+  }
+}
+
+export class ItemHelpers {
+  static extractLastContent(message: TResponseOutputItem): string {
+    if (!(message instanceof ResponseOutputMessage)) {
+      return '';
+    }
+
+    const lastContent = message.content[message.content.length - 1];
+    if (lastContent instanceof ResponseOutputText) {
+      return lastContent.text;
+    } else if (lastContent instanceof ResponseOutputRefusal) {
+      return lastContent.refusal;
+    } else {
+      throw new ModelBehaviorError(`Unexpected content type: ${typeof lastContent}`);
+    }
+  }
+
+  static extractLastText(message: TResponseOutputItem): string | null {
+    if (message instanceof ResponseOutputMessage) {
+      const lastContent = message.content[message.content.length - 1];
+      if (lastContent instanceof ResponseOutputText) {
+        return lastContent.text;
+      }
+    }
+    return null;
+  }
+
+  static inputToNewInputList(input: string | TResponseInputItem[]): TResponseInputItem[] {
+    if (typeof input === 'string') {
+      return [{ content: input, role: 'user' }];
+    }
+    return JSON.parse(JSON.stringify(input));
+  }
+
+  static textMessageOutputs(items: RunItem[]): string {
+    return items
+      .filter(item => item instanceof MessageOutputItem)
+      .map(item => this.textMessageOutput(item as MessageOutputItem))
+      .join('');
+  }
+
+  static textMessageOutput(message: MessageOutputItem): string {
+    return message.rawItem.content
+      .filter(item => item instanceof ResponseOutputText)
+      .map(item => (item as ResponseOutputText).text)
+      .join('');
+  }
+
+  static toolCallOutputItem(toolCall: ResponseFunctionToolCall, output: string): FunctionCallOutput {
+    return {
+      call_id: toolCall.call_id,
+      output,
+      type: 'function_call_output',
+    };
+  }
+}

--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -1,0 +1,81 @@
+import { Agent } from './agent';
+import { RunContextWrapper, TContext } from './run_context';
+import { Tool } from './tool';
+
+export class RunHooks<TContext> {
+  async onAgentStart(context: RunContextWrapper<TContext>, agent: Agent<TContext>): Promise<void> {
+    // Called before the agent is invoked. Called each time the current agent changes.
+  }
+
+  async onAgentEnd(
+    context: RunContextWrapper<TContext>,
+    agent: Agent<TContext>,
+    output: any
+  ): Promise<void> {
+    // Called when the agent produces a final output.
+  }
+
+  async onHandoff(
+    context: RunContextWrapper<TContext>,
+    fromAgent: Agent<TContext>,
+    toAgent: Agent<TContext>
+  ): Promise<void> {
+    // Called when a handoff occurs.
+  }
+
+  async onToolStart(
+    context: RunContextWrapper<TContext>,
+    agent: Agent<TContext>,
+    tool: Tool
+  ): Promise<void> {
+    // Called before a tool is invoked.
+  }
+
+  async onToolEnd(
+    context: RunContextWrapper<TContext>,
+    agent: Agent<TContext>,
+    tool: Tool,
+    result: string
+  ): Promise<void> {
+    // Called after a tool is invoked.
+  }
+}
+
+export class AgentHooks<TContext> {
+  async onStart(context: RunContextWrapper<TContext>, agent: Agent<TContext>): Promise<void> {
+    // Called before the agent is invoked. Called each time the running agent is changed to this agent.
+  }
+
+  async onEnd(
+    context: RunContextWrapper<TContext>,
+    agent: Agent<TContext>,
+    output: any
+  ): Promise<void> {
+    // Called when the agent produces a final output.
+  }
+
+  async onHandoff(
+    context: RunContextWrapper<TContext>,
+    agent: Agent<TContext>,
+    source: Agent<TContext>
+  ): Promise<void> {
+    // Called when the agent is being handed off to. The `source` is the agent that is handing off to this agent.
+  }
+
+  async onToolStart(
+    context: RunContextWrapper<TContext>,
+    agent: Agent<TContext>,
+    tool: Tool
+  ): Promise<void> {
+    // Called before a tool is invoked.
+  }
+
+  async onToolEnd(
+    context: RunContextWrapper<TContext>,
+    agent: Agent<TContext>,
+    tool: Tool,
+    result: string
+  ): Promise<void> {
+    // Called after a tool is invoked.
+  }
+}

--- a/src/agents/logger.ts
+++ b/src/agents/logger.ts
@@ -1,0 +1,16 @@
+import { createLogger, transports, format } from 'winston';
+
+const logger = createLogger({
+  level: 'info',
+  format: format.combine(
+    format.timestamp(),
+    format.printf(({ timestamp, level, message }) => {
+      return `${timestamp} ${level}: ${message}`;
+    })
+  ),
+  transports: [
+    new transports.Console(),
+  ],
+});
+
+export { logger };

--- a/src/agents/model_settings.ts
+++ b/src/agents/model_settings.ts
@@ -1,0 +1,44 @@
+export type ToolChoice = "auto" | "required" | "none";
+
+export class ModelSettings {
+  temperature?: number;
+  top_p?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
+  tool_choice?: ToolChoice | string;
+  parallel_tool_calls?: boolean;
+  truncation?: "auto" | "disabled";
+
+  constructor(
+    temperature?: number,
+    top_p?: number,
+    frequency_penalty?: number,
+    presence_penalty?: number,
+    tool_choice?: ToolChoice | string,
+    parallel_tool_calls?: boolean,
+    truncation?: "auto" | "disabled"
+  ) {
+    this.temperature = temperature;
+    this.top_p = top_p;
+    this.frequency_penalty = frequency_penalty;
+    this.presence_penalty = presence_penalty;
+    this.tool_choice = tool_choice;
+    this.parallel_tool_calls = parallel_tool_calls;
+    this.truncation = truncation;
+  }
+
+  resolve(override?: ModelSettings): ModelSettings {
+    if (!override) {
+      return this;
+    }
+    return new ModelSettings(
+      override.temperature ?? this.temperature,
+      override.top_p ?? this.top_p,
+      override.frequency_penalty ?? this.frequency_penalty,
+      override.presence_penalty ?? this.presence_penalty,
+      override.tool_choice ?? this.tool_choice,
+      override.parallel_tool_calls ?? this.parallel_tool_calls,
+      override.truncation ?? this.truncation
+    );
+  }
+}

--- a/src/agents/models/interface.ts
+++ b/src/agents/models/interface.ts
@@ -1,0 +1,46 @@
+import { AsyncIterator } from "asynciterator";
+import { AgentOutputSchema } from "../agent_output";
+import { Handoff } from "../handoffs";
+import { ModelResponse, TResponseInputItem, TResponseStreamEvent } from "../items";
+import { Tool } from "../tool";
+import { ModelSettings } from "../model_settings";
+
+export enum ModelTracing {
+  DISABLED = 0,
+  ENABLED = 1,
+  ENABLED_WITHOUT_DATA = 2,
+
+  is_disabled(): boolean {
+    return this === ModelTracing.DISABLED;
+  },
+
+  include_data(): boolean {
+    return this === ModelTracing.ENABLED;
+  }
+}
+
+export interface Model {
+  get_response(
+    system_instructions: string | null,
+    input: string | TResponseInputItem[],
+    model_settings: ModelSettings,
+    tools: Tool[],
+    output_schema: AgentOutputSchema | null,
+    handoffs: Handoff[],
+    tracing: ModelTracing
+  ): Promise<ModelResponse>;
+
+  stream_response(
+    system_instructions: string | null,
+    input: string | TResponseInputItem[],
+    model_settings: ModelSettings,
+    tools: Tool[],
+    output_schema: AgentOutputSchema | null,
+    handoffs: Handoff[],
+    tracing: ModelTracing
+  ): AsyncIterator<TResponseStreamEvent>;
+}
+
+export interface ModelProvider {
+  get_model(model_name: string | null): Model;
+}

--- a/src/agents/models/openai_chatcompletions.ts
+++ b/src/agents/models/openai_chatcompletions.ts
@@ -1,0 +1,121 @@
+import { AsyncIterator } from "asynciterator";
+import { AgentOutputSchema } from "../agent_output";
+import { Handoff } from "../handoffs";
+import { ModelResponse, TResponseInputItem, TResponseStreamEvent } from "../items";
+import { Tool } from "../tool";
+import { ModelSettings } from "../model_settings";
+import { Model, ModelTracing } from "./interface";
+import { OpenAI } from "openai";
+
+export class OpenAIChatCompletionsModel implements Model {
+  private model: string;
+  private openaiClient: OpenAI;
+
+  constructor(model: string, openaiClient: OpenAI) {
+    this.model = model;
+    this.openaiClient = openaiClient;
+  }
+
+  async get_response(
+    system_instructions: string | null,
+    input: string | TResponseInputItem[],
+    model_settings: ModelSettings,
+    tools: Tool[],
+    output_schema: AgentOutputSchema | null,
+    handoffs: Handoff[],
+    tracing: ModelTracing
+  ): Promise<ModelResponse> {
+    const response = await this.openaiClient.chat.completions.create({
+      model: this.model,
+      messages: this.convertInputToMessages(system_instructions, input),
+      temperature: model_settings.temperature,
+      top_p: model_settings.top_p,
+      frequency_penalty: model_settings.frequency_penalty,
+      presence_penalty: model_settings.presence_penalty,
+      tools: tools.map((tool) => this.convertTool(tool)),
+      output_schema: output_schema ? output_schema.json_schema() : undefined,
+      handoffs: handoffs.map((handoff) => this.convertHandoff(handoff)),
+      tracing: tracing.is_disabled() ? "disabled" : tracing.include_data() ? "enabled" : "enabled_without_data",
+    });
+
+    return this.convertResponse(response);
+  }
+
+  stream_response(
+    system_instructions: string | null,
+    input: string | TResponseInputItem[],
+    model_settings: ModelSettings,
+    tools: Tool[],
+    output_schema: AgentOutputSchema | null,
+    handoffs: Handoff[],
+    tracing: ModelTracing
+  ): AsyncIterator<TResponseStreamEvent> {
+    const stream = this.openaiClient.chat.completions.stream({
+      model: this.model,
+      messages: this.convertInputToMessages(system_instructions, input),
+      temperature: model_settings.temperature,
+      top_p: model_settings.top_p,
+      frequency_penalty: model_settings.frequency_penalty,
+      presence_penalty: model_settings.presence_penalty,
+      tools: tools.map((tool) => this.convertTool(tool)),
+      output_schema: output_schema ? output_schema.json_schema() : undefined,
+      handoffs: handoffs.map((handoff) => this.convertHandoff(handoff)),
+      tracing: tracing.is_disabled() ? "disabled" : tracing.include_data() ? "enabled" : "enabled_without_data",
+    });
+
+    return this.convertStream(stream);
+  }
+
+  private convertInputToMessages(system_instructions: string | null, input: string | TResponseInputItem[]): any[] {
+    const messages: any[] = [];
+
+    if (system_instructions) {
+      messages.push({
+        role: "system",
+        content: system_instructions,
+      });
+    }
+
+    for (const item of input) {
+      if (typeof item === "string") {
+        messages.push({
+          role: "user",
+          content: item,
+        });
+      } else {
+        messages.push(item);
+      }
+    }
+
+    return messages;
+  }
+
+  private convertTool(tool: Tool): any {
+    return {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.params_json_schema,
+    };
+  }
+
+  private convertHandoff(handoff: Handoff): any {
+    return {
+      name: handoff.tool_name,
+      description: handoff.tool_description,
+      parameters: handoff.input_json_schema,
+    };
+  }
+
+  private convertResponse(response: any): ModelResponse {
+    return {
+      output: response.choices[0].message,
+      usage: response.usage,
+      referenceable_id: response.id,
+    };
+  }
+
+  private convertStream(stream: any): AsyncIterator<TResponseStreamEvent> {
+    // Implement the conversion logic for the stream
+    return stream;
+  }
+}

--- a/src/agents/models/openai_provider.ts
+++ b/src/agents/models/openai_provider.ts
@@ -1,0 +1,63 @@
+import { AsyncOpenAI, DefaultAsyncHttpxClient } from "openai";
+import { Model, ModelProvider } from "./interface";
+import { OpenAIChatCompletionsModel } from "./openai_chatcompletions";
+import { OpenAIResponsesModel } from "./openai_responses";
+
+const DEFAULT_MODEL = "gpt-4o";
+
+let _http_client: DefaultAsyncHttpxClient | null = null;
+
+function sharedHttpClient(): DefaultAsyncHttpxClient {
+  if (_http_client === null) {
+    _http_client = new DefaultAsyncHttpxClient();
+  }
+  return _http_client;
+}
+
+export class OpenAIProvider implements ModelProvider {
+  private _client: AsyncOpenAI;
+  private _use_responses: boolean;
+
+  constructor({
+    api_key,
+    base_url,
+    openai_client,
+    organization,
+    project,
+    use_responses,
+  }: {
+    api_key?: string;
+    base_url?: string;
+    openai_client?: AsyncOpenAI;
+    organization?: string;
+    project?: string;
+    use_responses?: boolean;
+  } = {}) {
+    if (openai_client) {
+      if (api_key || base_url) {
+        throw new Error("Don't provide api_key or base_url if you provide openai_client");
+      }
+      this._client = openai_client;
+    } else {
+      this._client = new AsyncOpenAI({
+        api_key: api_key || process.env.OPENAI_API_KEY,
+        base_url,
+        organization,
+        project,
+        http_client: sharedHttpClient(),
+      });
+    }
+
+    this._use_responses = use_responses ?? true;
+  }
+
+  get_model(model_name: string | null): Model {
+    if (!model_name) {
+      model_name = DEFAULT_MODEL;
+    }
+
+    return this._use_responses
+      ? new OpenAIResponsesModel(model_name, this._client)
+      : new OpenAIChatCompletionsModel(model_name, this._client);
+  }
+}

--- a/src/agents/models/openai_responses.ts
+++ b/src/agents/models/openai_responses.ts
@@ -1,0 +1,116 @@
+import { AsyncIterator } from "asynciterator";
+import { AgentOutputSchema } from "../agent_output";
+import { Handoff } from "../handoffs";
+import { ModelResponse, TResponseInputItem, TResponseStreamEvent } from "../items";
+import { Tool } from "../tool";
+import { ModelSettings } from "../model_settings";
+import { Model, ModelTracing } from "./interface";
+import { OpenAI } from "openai";
+
+export class OpenAIResponsesModel implements Model {
+  private model: string;
+  private openaiClient: OpenAI;
+
+  constructor(model: string, openaiClient: OpenAI) {
+    this.model = model;
+    this.openaiClient = openaiClient;
+  }
+
+  async get_response(
+    system_instructions: string | null,
+    input: string | TResponseInputItem[],
+    model_settings: ModelSettings,
+    tools: Tool[],
+    output_schema: AgentOutputSchema | null,
+    handoffs: Handoff[],
+    tracing: ModelTracing
+  ): Promise<ModelResponse> {
+    const response = await this.openaiClient.responses.create({
+      model: this.model,
+      instructions: system_instructions,
+      input: this.convertInputToMessages(input),
+      temperature: model_settings.temperature,
+      top_p: model_settings.top_p,
+      frequency_penalty: model_settings.frequency_penalty,
+      presence_penalty: model_settings.presence_penalty,
+      tools: tools.map((tool) => this.convertTool(tool)),
+      output_schema: output_schema ? output_schema.json_schema() : undefined,
+      handoffs: handoffs.map((handoff) => this.convertHandoff(handoff)),
+      tracing: tracing.is_disabled() ? "disabled" : tracing.include_data() ? "enabled" : "enabled_without_data",
+    });
+
+    return this.convertResponse(response);
+  }
+
+  stream_response(
+    system_instructions: string | null,
+    input: string | TResponseInputItem[],
+    model_settings: ModelSettings,
+    tools: Tool[],
+    output_schema: AgentOutputSchema | null,
+    handoffs: Handoff[],
+    tracing: ModelTracing
+  ): AsyncIterator<TResponseStreamEvent> {
+    const stream = this.openaiClient.responses.stream({
+      model: this.model,
+      instructions: system_instructions,
+      input: this.convertInputToMessages(input),
+      temperature: model_settings.temperature,
+      top_p: model_settings.top_p,
+      frequency_penalty: model_settings.frequency_penalty,
+      presence_penalty: model_settings.presence_penalty,
+      tools: tools.map((tool) => this.convertTool(tool)),
+      output_schema: output_schema ? output_schema.json_schema() : undefined,
+      handoffs: handoffs.map((handoff) => this.convertHandoff(handoff)),
+      tracing: tracing.is_disabled() ? "disabled" : tracing.include_data() ? "enabled" : "enabled_without_data",
+    });
+
+    return this.convertStream(stream);
+  }
+
+  private convertInputToMessages(input: string | TResponseInputItem[]): any[] {
+    const messages: any[] = [];
+
+    for (const item of input) {
+      if (typeof item === "string") {
+        messages.push({
+          role: "user",
+          content: item,
+        });
+      } else {
+        messages.push(item);
+      }
+    }
+
+    return messages;
+  }
+
+  private convertTool(tool: Tool): any {
+    return {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.params_json_schema,
+    };
+  }
+
+  private convertHandoff(handoff: Handoff): any {
+    return {
+      name: handoff.tool_name,
+      description: handoff.tool_description,
+      parameters: handoff.input_json_schema,
+    };
+  }
+
+  private convertResponse(response: any): ModelResponse {
+    return {
+      output: response.choices[0].message,
+      usage: response.usage,
+      referenceable_id: response.id,
+    };
+  }
+
+  private convertStream(stream: any): AsyncIterator<TResponseStreamEvent> {
+    // Implement the conversion logic for the stream
+    return stream;
+  }
+}

--- a/src/agents/result.ts
+++ b/src/agents/result.ts
@@ -1,0 +1,209 @@
+import { Agent } from './agent';
+import { AgentOutputSchema } from './agent_output';
+import { InputGuardrailResult, OutputGuardrailResult } from './guardrail';
+import { ItemHelpers, ModelResponse, RunItem, TResponseInputItem } from './items';
+import { InputGuardrailTripwireTriggered, MaxTurnsExceeded } from './exceptions';
+import { StreamEvent } from './stream_events';
+import { Trace } from './tracing';
+import { QueueCompleteSentinel } from './_run_impl';
+import { logger } from './logger';
+import { Trace } from './tracing';
+import { QueueCompleteSentinel } from './_run_impl';
+import { logger } from './logger';
+
+export abstract class RunResultBase {
+  input: string | TResponseInputItem[];
+  newItems: RunItem[];
+  rawResponses: ModelResponse[];
+  finalOutput: any;
+  inputGuardrailResults: InputGuardrailResult[];
+  outputGuardrailResults: OutputGuardrailResult[];
+
+  constructor(
+    input: string | TResponseInputItem[],
+    newItems: RunItem[],
+    rawResponses: ModelResponse[],
+    finalOutput: any,
+    inputGuardrailResults: InputGuardrailResult[],
+    outputGuardrailResults: OutputGuardrailResult[]
+  ) {
+    this.input = input;
+    this.newItems = newItems;
+    this.rawResponses = rawResponses;
+    this.finalOutput = finalOutput;
+    this.inputGuardrailResults = inputGuardrailResults;
+    this.outputGuardrailResults = outputGuardrailResults;
+  }
+
+  abstract get lastAgent(): Agent<any>;
+
+  finalOutputAs<T>(cls: new (...args: any[]) => T, raiseIfIncorrectType = false): T {
+    if (raiseIfIncorrectType && !(this.finalOutput instanceof cls)) {
+      throw new TypeError(`Final output is not of type ${cls.name}`);
+    }
+    return this.finalOutput as T;
+  }
+
+  toInputList(): TResponseInputItem[] {
+    const originalItems = ItemHelpers.inputToNewInputList(this.input);
+    const newItems = this.newItems.map(item => item.toInputItem());
+    return originalItems.concat(newItems);
+  }
+}
+
+export class RunResult extends RunResultBase {
+  private _lastAgent: Agent<any>;
+
+  constructor(
+    input: string | TResponseInputItem[],
+    newItems: RunItem[],
+    rawResponses: ModelResponse[],
+    finalOutput: any,
+    inputGuardrailResults: InputGuardrailResult[],
+    outputGuardrailResults: OutputGuardrailResult[],
+    lastAgent: Agent<any>
+  ) {
+    super(input, newItems, rawResponses, finalOutput, inputGuardrailResults, outputGuardrailResults);
+    this._lastAgent = lastAgent;
+  }
+
+  get lastAgent(): Agent<any> {
+    return this._lastAgent;
+  }
+}
+
+export class RunResultStreaming extends RunResultBase {
+  currentAgent: Agent<any>;
+  currentTurn: number;
+  maxTurns: number;
+  finalOutput: any;
+  private _currentAgentOutputSchema: AgentOutputSchema | null;
+  private _trace: Trace | null;
+  isComplete: boolean;
+  private _eventQueue: AsyncQueue<StreamEvent | QueueCompleteSentinel>;
+  private _inputGuardrailQueue: AsyncQueue<InputGuardrailResult>;
+  private _runImplTask: Task<any> | null;
+  private _inputGuardrailsTask: Task<any> | null;
+  private _outputGuardrailsTask: Task<any> | null;
+  private _storedException: Exception | null;
+
+  constructor(
+    input: string | TResponseInputItem[],
+    newItems: RunItem[],
+    rawResponses: ModelResponse[],
+    finalOutput: any,
+    inputGuardrailResults: InputGuardrailResult[],
+    outputGuardrailResults: OutputGuardrailResult[],
+    currentAgent: Agent<any>,
+    currentTurn: number,
+    maxTurns: number,
+    currentAgentOutputSchema: AgentOutputSchema | null,
+    trace: Trace | null
+  ) {
+    super(input, newItems, rawResponses, finalOutput, inputGuardrailResults, outputGuardrailResults);
+    this.currentAgent = currentAgent;
+    this.currentTurn = currentTurn;
+    this.maxTurns = maxTurns;
+    this.finalOutput = finalOutput;
+    this._currentAgentOutputSchema = currentAgentOutputSchema;
+    this._trace = trace;
+    this.isComplete = false;
+    this._eventQueue = new AsyncQueue<StreamEvent | QueueCompleteSentinel>();
+    this._inputGuardrailQueue = new AsyncQueue<InputGuardrailResult>();
+    this._runImplTask = null;
+    this._inputGuardrailsTask = null;
+    this._outputGuardrailsTask = null;
+    this._storedException = null;
+  }
+
+  get lastAgent(): Agent<any> {
+    return this.currentAgent;
+  }
+
+  async *streamEvents(): AsyncIterable<StreamEvent> {
+    while (true) {
+      this._checkErrors();
+      if (this._storedException) {
+        logger.debug('Breaking due to stored exception');
+        this.isComplete = true;
+        break;
+      }
+
+      if (this.isComplete && this._eventQueue.isEmpty()) {
+        break;
+      }
+
+      try {
+        const item = await this._eventQueue.dequeue();
+        if (item instanceof QueueCompleteSentinel) {
+          this._eventQueue.complete();
+          this._checkErrors();
+          break;
+        }
+
+        yield item;
+        this._eventQueue.complete();
+      } catch (error) {
+        break;
+      }
+    }
+
+    if (this._trace) {
+      this._trace.finish(true);
+    }
+
+    this._cleanupTasks();
+
+    if (this._storedException) {
+      throw this._storedException;
+    }
+  }
+
+  private _checkErrors() {
+    if (this.currentTurn > this.maxTurns) {
+      this._storedException = new MaxTurnsExceeded(`Max turns (${this.maxTurns}) exceeded`);
+    }
+
+    while (!this._inputGuardrailQueue.isEmpty()) {
+      const guardrailResult = this._inputGuardrailQueue.dequeueSync();
+      if (guardrailResult.output.tripwireTriggered) {
+        this._storedException = new InputGuardrailTripwireTriggered(guardrailResult);
+      }
+    }
+
+    if (this._runImplTask && this._runImplTask.isDone()) {
+      const exc = this._runImplTask.getException();
+      if (exc) {
+        this._storedException = exc;
+      }
+    }
+
+    if (this._inputGuardrailsTask && this._inputGuardrailsTask.isDone()) {
+      const exc = this._inputGuardrailsTask.getException();
+      if (exc) {
+        this._storedException = exc;
+      }
+    }
+
+    if (this._outputGuardrailsTask && this._outputGuardrailsTask.isDone()) {
+      const exc = this._outputGuardrailsTask.getException();
+      if (exc) {
+        this._storedException = exc;
+      }
+    }
+  }
+
+  private _cleanupTasks() {
+    if (this._runImplTask && !this._runImplTask.isDone()) {
+      this._runImplTask.cancel();
+    }
+
+    if (this._inputGuardrailsTask && !this._inputGuardrailsTask.isDone()) {
+      this._inputGuardrailsTask.cancel();
+    }
+
+    if (this._outputGuardrailsTask && !this._outputGuardrailsTask.isDone()) {
+      this._outputGuardrailsTask.cancel();
+    }
+  }
+}

--- a/src/agents/run_context.ts
+++ b/src/agents/run_context.ts
@@ -1,0 +1,11 @@
+import { Usage } from './usage';
+
+export class RunContextWrapper<TContext = any> {
+  context: TContext;
+  usage: Usage;
+
+  constructor(context: TContext, usage: Usage = new Usage()) {
+    this.context = context;
+    this.usage = usage;
+  }
+}

--- a/src/agents/stream_events.ts
+++ b/src/agents/stream_events.ts
@@ -1,0 +1,20 @@
+import { Agent } from './agent';
+import { RunItem, TResponseStreamEvent } from './items';
+
+export interface RawResponsesStreamEvent {
+  data: TResponseStreamEvent;
+  type: 'raw_response_event';
+}
+
+export interface RunItemStreamEvent {
+  name: 'message_output_created' | 'handoff_requested' | 'handoff_occured' | 'tool_called' | 'tool_output' | 'reasoning_item_created';
+  item: RunItem;
+  type: 'run_item_stream_event';
+}
+
+export interface AgentUpdatedStreamEvent {
+  newAgent: Agent<any>;
+  type: 'agent_updated_stream_event';
+}
+
+export type StreamEvent = RawResponsesStreamEvent | RunItemStreamEvent | AgentUpdatedStreamEvent;

--- a/src/agents/tool.ts
+++ b/src/agents/tool.ts
@@ -1,0 +1,73 @@
+import { MaybeAwaitable } from './_utils';
+import { RunContextWrapper } from './run_context';
+import { FunctionTool, FileSearchTool, WebSearchTool, ComputerTool } from './tool';
+import { RunResult } from './result';
+import { ItemHelpers } from './items';
+
+export interface Tool {
+  name: string;
+  description: string;
+  run: (context: RunContextWrapper, input: string) => MaybeAwaitable<string>;
+}
+
+export function function_tool(options: {
+  nameOverride?: string;
+  descriptionOverride?: string;
+}) {
+  return function (target: (context: RunContextWrapper, input: string) => MaybeAwaitable<string>) {
+    const tool: Tool = {
+      name: options.nameOverride || target.name,
+      description: options.descriptionOverride || '',
+      run: target,
+    };
+    return tool;
+  };
+}
+
+export class FunctionTool implements Tool {
+  name: string;
+  description: string;
+  run: (context: RunContextWrapper, input: string) => MaybeAwaitable<string>;
+
+  constructor(name: string, description: string, run: (context: RunContextWrapper, input: string) => MaybeAwaitable<string>) {
+    this.name = name;
+    this.description = description;
+    this.run = run;
+  }
+}
+
+export class FileSearchTool implements Tool {
+  name: string;
+  description: string;
+  run: (context: RunContextWrapper, input: string) => MaybeAwaitable<string>;
+
+  constructor(name: string, description: string, run: (context: RunContextWrapper, input: string) => MaybeAwaitable<string>) {
+    this.name = name;
+    this.description = description;
+    this.run = run;
+  }
+}
+
+export class WebSearchTool implements Tool {
+  name: string;
+  description: string;
+  run: (context: RunContextWrapper, input: string) => MaybeAwaitable<string>;
+
+  constructor(name: string, description: string, run: (context: RunContextWrapper, input: string) => MaybeAwaitable<string>) {
+    this.name = name;
+    this.description = description;
+    this.run = run;
+  }
+}
+
+export class ComputerTool implements Tool {
+  name: string;
+  description: string;
+  run: (context: RunContextWrapper, input: string) => MaybeAwaitable<string>;
+
+  constructor(name: string, description: string, run: (context: RunContextWrapper, input: string) => MaybeAwaitable<string>) {
+    this.name = name;
+    this.description = description;
+    this.run = run;
+  }
+}

--- a/src/agents/tracing/index.ts
+++ b/src/agents/tracing/index.ts
@@ -1,0 +1,80 @@
+import atexit
+
+import {
+  agentSpan,
+  customSpan,
+  functionSpan,
+  generationSpan,
+  getCurrentSpan,
+  getCurrentTrace,
+  guardrailSpan,
+  handoffSpan,
+  responseSpan,
+  trace,
+} from './create';
+import { TracingProcessor } from './processor_interface';
+import { defaultExporter, defaultProcessor } from './processors';
+import { GLOBAL_TRACE_PROVIDER } from './setup';
+import {
+  AgentSpanData,
+  CustomSpanData,
+  FunctionSpanData,
+  GenerationSpanData,
+  GuardrailSpanData,
+  HandoffSpanData,
+  ResponseSpanData,
+  SpanData,
+} from './span_data';
+import { Span, SpanError } from './spans';
+import { Trace } from './traces';
+import { genSpanId, genTraceId } from './util';
+
+export {
+  addTraceProcessor,
+  agentSpan,
+  customSpan,
+  functionSpan,
+  generationSpan,
+  getCurrentSpan,
+  getCurrentTrace,
+  guardrailSpan,
+  handoffSpan,
+  responseSpan,
+  setTraceProcessors,
+  setTracingDisabled,
+  trace,
+  Trace,
+  SpanError,
+  Span,
+  SpanData,
+  AgentSpanData,
+  CustomSpanData,
+  FunctionSpanData,
+  GenerationSpanData,
+  GuardrailSpanData,
+  HandoffSpanData,
+  ResponseSpanData,
+  TracingProcessor,
+  genTraceId,
+  genSpanId,
+};
+
+function addTraceProcessor(spanProcessor: TracingProcessor): void {
+  GLOBAL_TRACE_PROVIDER.registerProcessor(spanProcessor);
+}
+
+function setTraceProcessors(processors: TracingProcessor[]): void {
+  GLOBAL_TRACE_PROVIDER.setProcessors(processors);
+}
+
+function setTracingDisabled(disabled: boolean): void {
+  GLOBAL_TRACE_PROVIDER.setDisabled(disabled);
+}
+
+function setTracingExportApiKey(apiKey: string): void {
+  defaultExporter().setApiKey(apiKey);
+}
+
+addTraceProcessor(defaultProcessor());
+
+atexit.register(GLOBAL_TRACE_PROVIDER.shutdown);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist"
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
Convert the codebase from Python to TypeScript.

* Add `src/agents/agent.ts` to implement the `Agent` class and its methods in TypeScript.
* Add `src/agents/computer.ts` to define the `Computer` and `AsyncComputer` interfaces in TypeScript.
* Add `src/agents/exceptions.ts` to implement exception classes in TypeScript.
* Add `src/agents/guardrail.ts` to implement `GuardrailFunctionOutput`, `InputGuardrail`, and `OutputGuardrail` classes in TypeScript.
* Add `src/agents/handoffs.ts` to implement the `Handoff` class and its methods in TypeScript.
* Add `src/agents/items.ts` to implement various item classes such as `RunItemBase`, `MessageOutputItem`, `HandoffCallItem`, `HandoffOutputItem`, `ToolCallItem`, `ToolCallOutputItem`, `ReasoningItem`, and `ModelResponse` in TypeScript.
* Add `src/agents/lifecycle.ts` to implement `RunHooks` and `AgentHooks` classes in TypeScript.
* Add `src/agents/logger.ts` to implement the logger using TypeScript.
* Add `src/agents/model_settings.ts` to implement the `ModelSettings` class in TypeScript.
* Add `src/agents/models/interface.ts` to define the `Model`, `ModelTracing`, and `ModelProvider` interfaces in TypeScript.
* Add `src/agents/models/openai_chatcompletions.ts` to implement the `OpenAIChatCompletionsModel` class in TypeScript.

